### PR TITLE
fix(ci): use uv pip install for mpak-scanner

### DIFF
--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -27,9 +27,7 @@ jobs:
         run: npx @anthropic-ai/mcpb pack
 
       - name: Run MTF scanner
-        run: |
-          uv pip install mpak-scanner
-          mpak-scanner scan *.mcpb --json > scan-results.json
+        run: uvx mpak-scanner scan *.mcpb --json > scan-results.json
 
       - name: Check for critical/high findings
         run: |

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -28,12 +28,8 @@ jobs:
 
       - name: Run MTF scanner
         run: |
-          if pip install mpak-scanner 2>/dev/null; then
-            mpak-scanner scan *.mcpb --json > scan-results.json
-          else
-            echo "mpak-scanner not yet available — skipping client-side scan"
-            echo '{"findings": []}' > scan-results.json
-          fi
+          uv pip install mpak-scanner
+          mpak-scanner scan *.mcpb --json > scan-results.json
 
       - name: Check for critical/high findings
         run: |


### PR DESCRIPTION
## Summary
- Replace bare `pip install mpak-scanner` with `uv pip install mpak-scanner` in `scan.yml`
- The workflow installs Python 3.13 via `uv`, but `pip` used the system Python (likely 3.12), causing `mpak-scanner` (which requires ≥3.13) to either fail silently or fake a clean scan report via the fallback

## Test plan
- [ ] Verify the `Security Scan` workflow passes on the PR
- [ ] Confirm `mpak-scanner` installs and runs under Python 3.13

🤖 Generated with [Claude Code](https://claude.com/claude-code)