### PR TITLE
Fix: load .env in integration test conftest

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,7 @@ dev = [
     "pytest>=8.4.0",
     "pytest-asyncio>=0.24.0",
     "pytest-cov>=6.0.0",
+    "python-dotenv>=1.0.0",
     "ruff>=0.13.0",
     "ty>=0.0.20",
 ]

--- a/tests-integration/conftest.py
+++ b/tests-integration/conftest.py
@@ -9,8 +9,11 @@ import os
 
 import pytest
 import pytest_asyncio
+from dotenv import load_dotenv
 
 from mcp_example.api_client import ExampleClient
+
+load_dotenv()
 
 
 def pytest_configure(config):


### PR DESCRIPTION
## Summary
- Add `python-dotenv` to dev dependencies in `pyproject.toml`
- Call `load_dotenv()` in `tests-integration/conftest.py` before the env var gate

Closes #7