### PR TITLE
fix: add anthropic to dev dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,7 @@ dev = [
     "pytest-cov>=6.0.0",
     "ruff>=0.13.0",
     "ty>=0.0.20",
+    "anthropic>=0.40.0",
 ]
 
 [project.urls]


### PR DESCRIPTION
## Summary
- Add `anthropic>=0.40.0` to `[dependency-groups] dev` in `pyproject.toml`
- Fixes `ModuleNotFoundError` when running `make test-llm`

Closes https://github.com/NimbleBrainInc/mcp-server-template-python/issues/9