### PR TITLE
Fix SKILL.md scaffold and wiring-only unit test

### DIFF
--- a/src/mcp_example/SKILL.md
+++ b/src/mcp_example/SKILL.md
@@ -1,18 +1,18 @@
-# Example MCP Server — Skill Guide
+---
+name: mcp-example-service
+description: Provides knowledge of how to use MCP example most effectively. It's loaded into the agent's context when running the MCP.
+---
 
 ## Tools
 
+<!-- TODO: Add a row for each @mcp.tool() in server.py -->
 | Tool | Use when... |
 |------|-------------|
-| `list_items` | You need to browse or search items |
-| `get_item` | You have an item ID and need full details |
 
 ## Context Reuse
 
-- Use the `id` from `list_items` results when calling `get_item`
+<!-- TODO: Describe which tool outputs feed into subsequent tool calls -->
 
 ## Workflows
 
-### 1. Browse and Inspect
-1. `list_items` with a limit to get an overview
-2. For interesting items: `get_item` to get full details
+<!-- TODO: Add 2-3 multi-step workflows showing how to chain tools -->

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -35,8 +35,8 @@ class TestSkillResource:
         async with Client(mcp_server) as client:
             contents = await client.read_resource("skill://example/usage")
             text = contents[0].text if hasattr(contents[0], "text") else str(contents[0])
-            assert "list_items" in text
-            assert "get_item" in text
+            assert len(text.strip()) > 0
+            assert "## Tools" in text
 
     @pytest.mark.asyncio
     async def test_skill_content_matches_constant(self, mcp_server):


### PR DESCRIPTION
## Summary

- Replace the fully-populated `SKILL.md` (hardcoded `list_items`/`get_item`) with a TODO scaffold — frontmatter + section headings, no tool names
- Change `test_skill_resource_readable` from asserting specific tool names to asserting non-empty content with expected structure (`## Tools` heading)

This fixes a break in the [build-mcpb pipeline](https://github.com/NimbleBrainInc/contributor-toolkit) where Phase 3 (Implement & Verify) replaces template tools with real ones, but SKILL.md isn't customized until Phase 5 (Embed Skill). The unit test was asserting tool names that no longer existed.

Related: NimbleBrainInc/contributor-toolkit#43

## Test plan

- [x] `uv run pytest tests/ -v` — all 25 tests pass with the scaffold SKILL.md