### PR TITLE
Anchor project-only patterns in .mcpbignore template

### DIFF
--- a/.mcpbignore
+++ b/.mcpbignore
@@ -1,40 +1,45 @@
-# Development environment
-.venv/
-.git/
-.github/
-.pytest_cache/
+# mcpb pack loads this file and treats each pattern as gitignore-style.
+# Gitignore rule that bites: a pattern without a leading `/` matches
+# anywhere in the tree, including inside `deps/`. Unanchored `conftest.py`
+# or `tests/` happily strips vendored `deps/<pkg>/.../conftest.py` and
+# breaks imports at runtime. Anchor project-only patterns with `/`.
+
+# ── Strip anywhere (generated/OS cruft — safe to remove from deps/) ──
 __pycache__/
 *.pyc
-
-# Cache directories
-.ruff_cache/
-.coverage
-
-# Test files
-tests/
-
-# Build artifacts
-dist/
-build/
-*.egg-info/
+*.pyo
+*.pyi
+.DS_Store
 *.mcpb
 
-# Dev config
-Makefile
-pytest.ini
-.env
-.env.*
-
-# Lock files
-uv.lock
-
-# IDE
-.vscode/
-.idea/
-
-# Docs (not needed in bundle)
-CLAUDE.md
-CONTRIBUTING.md
-
-# Images
-*.png
+# ── Project-only (anchored) ──
+/.venv/
+/.git/
+/.github/
+/.claude/
+/.vscode/
+/.idea/
+/.env
+/.env.*
+/.python-version
+/.pytest_cache/
+/.ruff_cache/
+/.ty_cache/
+/.mypy_cache/
+/.coverage
+/build/
+/dist/
+/tests/
+/test/
+/e2e/
+/examples/
+/docs/
+/doc/
+/scripts/
+/htmlcov/
+/Makefile
+/Dockerfile
+/pytest.ini
+/uv.lock
+/CLAUDE.md
+/CONTRIBUTING.md


### PR DESCRIPTION
## Summary

- Unanchored gitignore patterns in \`.mcpbignore\` match anywhere in the tree, including inside vendored \`deps/\`. \`mcpb pack\` then strips legitimate runtime files from bundled packages, breaking imports at startup.
- Discovered via \`synapse-research\`: \`conftest.py\` in \`.mcpbignore\` stripped \`deps/beartype/_conf/conftest.py\` (a real runtime module, not a pytest config), and the bundle failed with \`MCP error -32000: Connection closed\`. Fixed in \`synapse-research@0.1.2\`.
- This template change anchors project-only patterns with leading \`/\` and drops \`conftest.py\` (redundant with \`/tests/\`; too greedy).

## Test plan

- [ ] Create a new Python MCP server from this template
- [ ] Run \`make bundle\` and confirm \`deps/\` modules with names like \`conftest.py\` are retained