### PR TITLE
Install dev skills via npx skills (mpak skill removed)

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-server.md
+++ b/.github/ISSUE_TEMPLATE/new-server.md
@@ -31,9 +31,9 @@ assignees: ''
 
 ```bash
 # 1. Install development skills
-mpak skill install @nimblebraininc/build-mcp
-mpak skill install @nimblebraininc/validate-mcpb
-mpak skill install @nimblebraininc/author-skills-for-server
+npx skills add nimblebraininc/skills --skill build-mcp
+npx skills add nimblebraininc/skills --skill validate-mcpb
+npx skills add nimblebraininc/skills --skill author-skills-for-server
 
 # 2. Create repo from template
 gh repo create NimbleBrainInc/mcp-<name> --template NimbleBrainInc/mcp-server-template --public --clone

--- a/.github/ISSUE_TEMPLATE/new-server.md
+++ b/.github/ISSUE_TEMPLATE/new-server.md
@@ -30,21 +30,16 @@ assignees: ''
 ## Getting Started
 
 ```bash
-# 1. Install development skills
-npx skills add nimblebraininc/skills --skill build-mcp
-npx skills add nimblebraininc/skills --skill validate-mcpb
-npx skills add nimblebraininc/skills --skill author-skills-for-server
+# 1. Install the build skill
+npx skills add nimblebraininc/skills --skill mcpb --agent claude-code -y
 
 # 2. Create repo from template
 gh repo create NimbleBrainInc/mcp-<name> --template NimbleBrainInc/mcp-server-template --public --clone
 
-# 3. Use /build-mcp to scaffold, or start from the template code
+# 3. Run /mcpb — scaffolds the server, implements tools, validates the
+#    bundle (MTF scan), and authors companion skills, end to end
 
-# 4. Implement tools, run make check
-
-# 5. Validate bundle with /validate-mcpb
-
-# 6. Author companion skills with /author-skills-for-server
+# 4. Iterate with `make check` as you build
 ```
 
 ## Definition of Done

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -37,7 +37,6 @@
 ### Skills (if applicable)
 - [ ] SKILL.md with complete frontmatter + metadata
 - [ ] Composes 2+ tools into a workflow
-- [ ] `mpak skill validate` passes
 - [ ] At least 2 usage examples
 
 ## Testing

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,8 +29,8 @@ make check
 These skills automate common development tasks:
 
 ```bash
-mpak skill install @nimblebraininc/nimblebrain-contributor
-mpak skill install @nimblebraininc/build-mcpb
+npx skills add nimblebraininc/skills --skill nimblebrain-contributor
+npx skills add nimblebraininc/skills --skill build-mcpb
 ```
 
 ## Development Workflow
@@ -92,5 +92,4 @@ Or simply: `make check`
 ### For Companion Skills
 - SKILL.md with complete frontmatter
 - Composes 2+ tools into a workflow
-- `mpak skill validate` passes
 - At least 2 usage examples

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,8 +29,8 @@ make check
 These skills automate common development tasks:
 
 ```bash
-npx skills add nimblebraininc/skills --skill nimblebrain-contributor
-npx skills add nimblebraininc/skills --skill build-mcpb
+npx skills add nimblebraininc/skills --skill contributor --agent claude-code -y
+npx skills add nimblebraininc/skills --skill mcpb --agent claude-code -y
 ```
 
 ## Development Workflow


### PR DESCRIPTION
## Stage 4 (external consumers) — Python server template

mpak removed the `mpak skill` CLI namespace; the development skills moved to [nimblebraininc/skills](https://github.com/NimbleBrainInc/skills) and install via the open Agent Skills standard.

### Changes
- **CONTRIBUTING.md** + **ISSUE_TEMPLATE/new-server.md** — install dev skills with `npx skills add nimblebraininc/skills --skill <name>` instead of `mpak skill install`
- **CONTRIBUTING.md** + **PULL_REQUEST_TEMPLATE.md** — drop the removed `mpak skill validate` step (companion skills ship embedded as `skill://` resources in the bundle)

Part of the mpak bundle-only refocus (mpak #124/#125/#126).